### PR TITLE
Configure Celery scheduling for notifications and user cleanup

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app
+
+__all__ = ("celery_app",)

--- a/config/celery.py
+++ b/config/celery.py
@@ -1,0 +1,14 @@
+import os
+
+from celery import Celery
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+app = Celery("config")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+app.autodiscover_tasks()
+
+
+@app.task(bind=True)
+def debug_task(self):  # pragma: no cover - helper task for debugging
+    print(f"Request: {self.request!r}")

--- a/config/settings.py
+++ b/config/settings.py
@@ -10,8 +10,10 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 import os
-from dotenv import load_dotenv
 from pathlib import Path
+
+from celery.schedules import crontab
+from dotenv import load_dotenv
 
 load_dotenv(override=True)
 
@@ -161,3 +163,23 @@ STRIPE_SECRET_KEY = os.getenv("STRIPE_SECRET_KEY", "")
 STRIPE_SUCCESS_URL = os.getenv("STRIPE_SUCCESS_URL", "https://example.com/success")
 STRIPE_CANCEL_URL = os.getenv("STRIPE_CANCEL_URL", "https://example.com/cancel")
 STRIPE_CURRENCY = os.getenv("STRIPE_CURRENCY", "rub")
+
+DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "noreply@example.com")
+
+REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
+REDIS_PORT = os.getenv("REDIS_PORT", "6379")
+REDIS_DB = os.getenv("REDIS_DB", "0")
+REDIS_URL = os.getenv("REDIS_URL", f"redis://{REDIS_HOST}:{REDIS_PORT}/{REDIS_DB}")
+
+CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", REDIS_URL)
+CELERY_RESULT_BACKEND = os.getenv("CELERY_RESULT_BACKEND", REDIS_URL)
+CELERY_TIMEZONE = TIME_ZONE
+CELERY_ENABLE_UTC = USE_TZ
+CELERY_TASK_SERIALIZER = "json"
+CELERY_ACCEPT_CONTENT = ["json"]
+CELERY_BEAT_SCHEDULE = {
+    "deactivate-inactive-users": {
+        "task": "users.tasks.deactivate_inactive_users",
+        "schedule": crontab(hour=0, minute=0),
+    }
+}

--- a/courses/migrations/0006_course_updated_at.py
+++ b/courses/migrations/0006_course_updated_at.py
@@ -1,0 +1,18 @@
+import django.utils.timezone
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('courses', '0005_subscription'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='course',
+            name='updated_at',
+            field=models.DateTimeField(auto_now=True, default=django.utils.timezone.now, verbose_name='обновлено'),
+            preserve_default=False,
+        ),
+    ]

--- a/courses/models.py
+++ b/courses/models.py
@@ -1,11 +1,13 @@
 from django.db import models
 from django.conf import settings
+from django.utils import timezone
 
 class Course(models.Model):
     title = models.CharField(max_length=150, verbose_name='название')
     preview = models.ImageField(upload_to='courses/', blank=True, null=True, verbose_name='превью')
     description = models.TextField(verbose_name='описание')
     owner = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='courses', null=True, blank=True)
+    updated_at = models.DateTimeField(auto_now=True, verbose_name='обновлено')
 
     def __str__(self):
         return f'{self.title}'
@@ -26,6 +28,11 @@ class Lesson(models.Model):
 
     def __str__(self):
         return f'{self.title}'
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        if self.course_id:
+            Course.objects.filter(pk=self.course_id).update(updated_at=timezone.now())
 
     class Meta:
         verbose_name = 'урок'

--- a/courses/tasks.py
+++ b/courses/tasks.py
@@ -1,0 +1,38 @@
+from celery import shared_task
+from django.conf import settings
+from django.core.mail import send_mail
+
+from courses.models import Course, Subscription
+
+
+@shared_task
+def send_course_update_notifications(course_id: int) -> int:
+    """Send notifications about course updates to subscribed users."""
+    try:
+        course = Course.objects.get(pk=course_id)
+    except Course.DoesNotExist:
+        return 0
+
+    subscriptions = (
+        Subscription.objects
+        .filter(course_id=course_id)
+        .select_related("user")
+        .only("user__email")
+    )
+    recipients = [sub.user.email for sub in subscriptions if sub.user and sub.user.email]
+
+    if not recipients:
+        return 0
+
+    subject = f"Обновление курса «{course.title}»"
+    message = (
+        "Материалы курса были обновлены. Зайдите в личный кабинет, чтобы ознакомиться с новыми материалами."
+    )
+
+    return send_mail(
+        subject,
+        message,
+        getattr(settings, "DEFAULT_FROM_EMAIL", None),
+        recipients,
+        fail_silently=True,
+    )

--- a/courses/views.py
+++ b/courses/views.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from rest_framework import viewsets, generics, permissions, status
 from drf_spectacular.utils import extend_schema
 
@@ -6,15 +8,29 @@ from courses.serializers import CourseSerializer, LessonSerializer, Subscription
 from django.db.models import Count, Prefetch, Exists, OuterRef
 from rest_framework.decorators import action
 from rest_framework.response import Response
+from django.utils import timezone
 
 from .models import Course, Lesson, Subscription
 from .paginators import DefaultPagination
+from .tasks import send_course_update_notifications
 
 
 class CourseViewSet(viewsets.ModelViewSet):
     queryset = Course.objects.all().order_by('id')
     serializer_class = CourseSerializer
     pagination_class = DefaultPagination
+
+    def perform_update(self, serializer):
+        previous_updated_at = getattr(serializer.instance, "updated_at", None)
+        course = serializer.save()
+
+        should_notify = True
+        if previous_updated_at is not None:
+            elapsed = timezone.now() - previous_updated_at
+            should_notify = elapsed >= timedelta(hours=4)
+
+        if should_notify and course.subscriptions.exists():
+            send_course_update_notifications.delay(course.pk)
 
     def get_permissions(self):
         # Базовое требование: JWT

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,7 @@ pillow==11.3.0
 psycopg2-binary==2.9.10
 PyJWT==2.10.1
 python-dotenv==1.1.1
+celery==5.4.0
+redis==5.2.1
 sqlparse==0.5.3
 stripe==10.13.0

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -1,0 +1,23 @@
+from datetime import timedelta
+
+from celery import shared_task
+from django.contrib.auth import get_user_model
+from django.db import models
+from django.utils import timezone
+
+
+@shared_task
+def deactivate_inactive_users() -> int:
+    """Deactivate users who have been inactive for more than 30 days."""
+    User = get_user_model()
+    threshold = timezone.now() - timedelta(days=30)
+
+    affected_users = User.objects.filter(
+        is_active=True,
+    ).filter(
+        models.Q(last_login__lt=threshold)
+        | models.Q(last_login__isnull=True, date_joined__lt=threshold)
+    )
+
+    updated = affected_users.update(is_active=False)
+    return updated


### PR DESCRIPTION
## Summary
- configure Celery with Redis-based broker, result backend, and beat schedule
- add Celery tasks for notifying course subscribers after updates and deactivating stale accounts
- extend the course model with an updated_at timestamp and throttle notifications to once every four hours

## Testing
- python -m compileall config courses users

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fbe15e4b483288ea6abe0b1889654)