### PR TITLE
Add Docker Compose configuration for local stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,30 @@
 # Django settings
 SECRET_KEY=your_secret_key
 DEBUG=True
+DJANGO_PORT=8000
 
 # Database configuration
-DB_NAME=your_database_name
-DB_USER=your_database_user
-DB_PASSWORD=your_database_password
-DB_HOST=localhost
+DB_NAME=postgres
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_HOST=db
 DB_PORT=5432
+
+# Redis configuration
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_DB=0
+REDIS_URL=redis://redis:6379/0
+
+# Celery configuration
+CELERY_BROKER_URL=redis://redis:6379/0
+CELERY_RESULT_BACKEND=redis://redis:6379/0
 
 # Stripe integration
 STRIPE_SECRET_KEY=sk_test_your_secret_key
 STRIPE_SUCCESS_URL=https://example.com/success
 STRIPE_CANCEL_URL=https://example.com/cancel
 STRIPE_CURRENCY=rub
+
+# Email
+DEFAULT_FROM_EMAIL=noreply@example.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Домашнее задание: DRF (HW_SP_30_1)
 
 ## 📋 Описание
-Учебный проект на **Django REST Framework**.  
+Учебный проект на **Django REST Framework**.
 Содержит два приложения:
 - `courses` — курсы и уроки
 - `users` — пользователи и платежи
@@ -14,7 +14,49 @@
 
 ---
 
-## ⚙️ Установка и запуск
+## 🚀 Запуск через Docker Compose
+
+1. Скопируйте шаблон переменных окружения и заполните нужные значения:
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Поднимите весь стек сервисов (бэкенд, PostgreSQL, Redis, Celery worker и Celery Beat):
+   ```bash
+   docker compose up --build
+   ```
+   По умолчанию Django будет доступен на `http://localhost:8000`.
+
+3. После первого запуска проверьте, что все сервисы работают:
+   - **Бэкенд** — откройте `http://localhost:8000/api/schema/swagger-ui/` или выполните запрос:
+     ```bash
+     curl http://localhost:8000/api/v1/courses/
+     ```
+   - **PostgreSQL** — проверьте подключение и список баз данных:
+     ```bash
+     docker compose exec db psql -U "$DB_USER" -d "$DB_NAME" -c '\l'
+     ```
+   - **Redis** — выполните ping:
+     ```bash
+     docker compose exec redis redis-cli ping
+     ```
+   - **Celery worker** — посмотрите активные логи:
+     ```bash
+     docker compose logs celery
+     ```
+   - **Celery Beat** — убедитесь, что планировщик запустился:
+     ```bash
+     docker compose logs celery_beat
+     ```
+
+4. Остановить и удалить контейнеры можно командой:
+   ```bash
+   docker compose down -v
+   ```
+
+---
+
+## ⚙️ Локальная установка без Docker
 
 1. Клонировать репозиторий:
    ```bash
@@ -70,22 +112,22 @@ python manage.py seed_payments
 ## 🔗 Эндпоинты API
 
 ### Users
-- `GET /api/v1/users/` — список пользователей  
-- `GET /api/v1/users/{id}/` — профиль пользователя  
+- `GET /api/v1/users/` — список пользователей
+- `GET /api/v1/users/{id}/` — профиль пользователя
 
 ### Courses
-- `GET /api/v1/courses/` — список курсов (есть `lessons_count`)  
-- `GET /api/v1/courses/{id}/` — детальный курс (есть `lessons_count` + список `lessons`)  
+- `GET /api/v1/courses/` — список курсов (есть `lessons_count`)
+- `GET /api/v1/courses/{id}/` — детальный курс (есть `lessons_count` + список `lessons`)
 
 ### Lessons
-- `GET /api/v1/lessons/` — список уроков  
-- `POST /api/v1/lessons/create/` — создать урок  
-- `GET /api/v1/lessons/{id}/` — детальный урок  
-- `PUT/PATCH /api/v1/lessons/{id}/update/` — обновить урок  
-- `DELETE /api/v1/lessons/{id}/delete/` — удалить урок  
+- `GET /api/v1/lessons/` — список уроков
+- `POST /api/v1/lessons/create/` — создать урок
+- `GET /api/v1/lessons/{id}/` — детальный урок
+- `PUT/PATCH /api/v1/lessons/{id}/update/` — обновить урок
+- `DELETE /api/v1/lessons/{id}/delete/` — удалить урок
 
 ### Payments
-- `GET /api/v1/payments/` — список платежей  
+- `GET /api/v1/payments/` — список платежей
   - фильтрация:
     - `?course=1`
     - `?lesson=3`
@@ -93,10 +135,10 @@ python manage.py seed_payments
   - сортировка:
     - `?ordering=paid_at`
     - `?ordering=-paid_at`
-- `POST /api/v1/payments/create/` — создать платеж  
-- `GET /api/v1/payments/{id}/` — детальный платеж  
-- `PUT/PATCH /api/v1/payments/{id}/update/` — обновить платеж  
-- `DELETE /api/v1/payments/{id}/delete/` — удалить платеж  
+- `POST /api/v1/payments/create/` — создать платеж
+- `GET /api/v1/payments/{id}/` — детальный платеж
+- `PUT/PATCH /api/v1/payments/{id}/update/` — обновить платеж
+- `DELETE /api/v1/payments/{id}/delete/` — удалить платеж
 
 ---
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,83 @@
+version: "3.9"
+
+services:
+  backend:
+    build:
+      context: .
+    command: >-
+      sh -c "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+    ports:
+      - "${DJANGO_PORT:-8000}:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    restart: unless-stopped
+
+  celery:
+    build:
+      context: .
+    command: celery -A config worker -l info
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    restart: unless-stopped
+
+  celery_beat:
+    build:
+      context: .
+    command: celery -A config beat -l info
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+    depends_on:
+      redis:
+        condition: service_started
+    restart: unless-stopped
+
+  db:
+    image: postgres:16-alpine
+    ports:
+      - "${DB_PORT:-5432}:5432"
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    env_file:
+      - .env
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    command: redis-server --save 20 1 --loglevel warning
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+  redis_data:


### PR DESCRIPTION
## Summary
- add a Dockerfile and docker-compose stack to run Django, PostgreSQL, Redis, Celery worker, and Celery Beat together
- extend the environment template with Redis/Celery variables and document Compose usage in the README

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fc62db2848328980a42a6212f2bb3)