### PR TITLE
Add CI/CD pipeline and deployment documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,29 +1,28 @@
-# Django settings
-SECRET_KEY=your_secret_key
-DEBUG=True
-DJANGO_PORT=8000
+# Django core settings
+SECRET_KEY=change-me
+DEBUG=False
+ALLOWED_HOSTS=example.com,www.example.com
+CSRF_TRUSTED_ORIGINS=https://example.com,https://www.example.com
 
 # Database configuration
-DB_NAME=postgres
-DB_USER=postgres
-DB_PASSWORD=postgres
-DB_HOST=db
+DB_ENGINE=postgres
+DB_NAME=hw_sp_30_1
+DB_USER=hw_sp
+DB_PASSWORD=change-me
+DB_HOST=127.0.0.1
 DB_PORT=5432
 
-# Redis configuration
-REDIS_HOST=redis
+# Redis / Celery
+REDIS_HOST=127.0.0.1
 REDIS_PORT=6379
 REDIS_DB=0
-REDIS_URL=redis://redis:6379/0
-
-# Celery configuration
-CELERY_BROKER_URL=redis://redis:6379/0
-CELERY_RESULT_BACKEND=redis://redis:6379/0
+CELERY_BROKER_URL=redis://127.0.0.1:6379/0
+CELERY_RESULT_BACKEND=redis://127.0.0.1:6379/0
 
 # Stripe integration
-STRIPE_SECRET_KEY=sk_test_your_secret_key
-STRIPE_SUCCESS_URL=https://example.com/success
-STRIPE_CANCEL_URL=https://example.com/cancel
+STRIPE_SECRET_KEY=
+STRIPE_SUCCESS_URL=https://example.com/payments/success/
+STRIPE_CANCEL_URL=https://example.com/payments/cancel/
 STRIPE_CURRENCY=rub
 
 # Email

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -1,0 +1,85 @@
+name: CI/CD
+
+on:
+  push:
+    branches:
+      - '**'
+
+env:
+  PYTHON_VERSION: '3.12'
+  DJANGO_SETTINGS_MODULE: config.settings
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run Django tests
+        env:
+          SECRET_KEY: dummy
+          DEBUG: 'True'
+          DB_ENGINE: sqlite
+        run: |
+          python manage.py migrate --noinput
+          python manage.py test
+
+  deploy:
+    needs: tests
+    if: github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Add SSH key
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_SSH_KEY }}
+
+      - name: Add known hosts
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Upload deploy script
+        run: |
+          scp deploy/deploy.sh ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/tmp/deploy_hw_sp_30_1.sh
+
+      - name: Deploy to server
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_APP_DIR: ${{ secrets.DEPLOY_APP_DIR }}
+          DEPLOY_VENV_PATH: ${{ secrets.DEPLOY_VENV_PATH }}
+          DEPLOY_SERVICE: ${{ secrets.DEPLOY_SERVICE_NAME }}
+          DEPLOY_ENV_FILE: ${{ secrets.DEPLOY_ENV_FILE }}
+        run: |
+          ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+            APP_DIR="$DEPLOY_APP_DIR" \
+            VENV_PATH="$DEPLOY_VENV_PATH" \
+            SERVICE_NAME="$DEPLOY_SERVICE" \
+            ENV_FILE="${DEPLOY_ENV_FILE:-$DEPLOY_APP_DIR/.env}" \
+            GIT_REF="$GITHUB_REF_NAME" \
+            bash /tmp/deploy_hw_sp_30_1.sh
+
+      - name: Cleanup deploy script
+        if: always()
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+        run: |
+          ssh "$DEPLOY_USER@$DEPLOY_HOST" rm -f /tmp/deploy_hw_sp_30_1.sh

--- a/README.md
+++ b/README.md
@@ -148,3 +148,119 @@ python manage.py seed_payments
 - Django REST Framework
 - django-filter
 - PostgreSQL (можно заменить на SQLite для тестов)
+
+---
+
+## ☁️ Продовый сервер и деплой
+
+### 1. Подготовьте удалённый сервер
+- Создайте пользователя без привилегий `sudo adduser deploy && usermod -aG sudo deploy`.
+- Включите авторизацию по SSH-ключам: скопируйте публичный ключ на сервер `ssh-copy-id deploy@<SERVER_IP>` и отключите парольный вход в `/etc/ssh/sshd_config` (`PasswordAuthentication no`).
+- Обновите систему и установите базовые пакеты:
+  ```bash
+  sudo apt update && sudo apt upgrade -y
+  sudo apt install -y python3 python3-venv python3-pip git nginx postgresql postgresql-contrib redis-server
+  ```
+- Настройте firewall, оставив только нужные порты (например, 22/80/443):
+  ```bash
+  sudo ufw allow OpenSSH
+  sudo ufw allow 'Nginx Full'
+  sudo ufw enable
+  ```
+
+### 2. Создайте инфраструктуру проекта
+- Настройте базу данных PostgreSQL:
+  ```sql
+  sudo -u postgres psql
+  CREATE DATABASE hw_sp_30_1;
+  CREATE USER hw_sp WITH PASSWORD 'strong_password';
+  ALTER ROLE hw_sp SET client_encoding TO 'utf8';
+  ALTER ROLE hw_sp SET default_transaction_isolation TO 'read committed';
+  ALTER ROLE hw_sp SET timezone TO 'UTC';
+  GRANT ALL PRIVILEGES ON DATABASE hw_sp_30_1 TO hw_sp;
+  \q
+  ```
+- Создайте структуру каталогов и клон репозитория:
+  ```bash
+  sudo mkdir -p /srv/hw_sp_30_1
+  sudo chown deploy:deploy /srv/hw_sp_30_1
+  cd /srv/hw_sp_30_1
+  git clone git@github.com:Kub-mi/HW_SP_30_1.git app
+  python3 -m venv venv
+  source venv/bin/activate
+  pip install --upgrade pip
+  pip install -r app/requirements.txt
+  ```
+- Скопируйте шаблон `.env` и заполните чувствительные данные:
+  ```bash
+  cd /srv/hw_sp_30_1/app
+  cp .env.example .env
+  nano .env  # заполните секретный ключ, параметры БД, Stripe и т.д.
+  ```
+- Выполните подготовительные команды:
+  ```bash
+  source /srv/hw_sp_30_1/venv/bin/activate
+  python manage.py migrate --noinput
+  python manage.py collectstatic --noinput
+  ```
+
+### 3. Настройте systemd и Gunicorn
+- Используйте шаблон `infra/hw_sp_30_1.service` и отредактируйте пути при необходимости:
+  ```bash
+  sudo cp infra/hw_sp_30_1.service /etc/systemd/system/hw_sp_30_1.service
+  sudo mkdir -p /var/log/hw_sp_30_1
+  sudo chown www-data:www-data /var/log/hw_sp_30_1
+  sudo systemctl daemon-reload
+  sudo systemctl enable hw_sp_30_1.service
+  sudo systemctl start hw_sp_30_1.service
+  sudo systemctl status hw_sp_30_1.service
+  ```
+- Убедитесь, что Gunicorn слушает порт `8000`. Перезапуск произойдёт автоматически при деплое через GitHub Actions.
+
+### 4. Настройте Nginx
+- Скопируйте шаблон `infra/nginx.conf` и укажите свой домен/IP:
+  ```bash
+  sudo cp infra/nginx.conf /etc/nginx/sites-available/hw_sp_30_1
+  sudo ln -s /etc/nginx/sites-available/hw_sp_30_1 /etc/nginx/sites-enabled/
+  sudo nginx -t
+  sudo systemctl reload nginx
+  ```
+- Для HTTPS подключите Certbot или другой инструмент по инструкции официальной документации Nginx/Let's Encrypt.
+
+### 5. Автоматический рестарт Celery (опционально)
+Если используете Celery, настройте отдельные сервисы `systemd` для worker и beat, аналогично Gunicorn.
+
+---
+
+## 🤖 GitHub Actions: CI/CD
+
+Workflow находится в `.github/workflows/ci_cd.yml` и запускается при каждом `push`.
+
+### Job `tests`
+- Устанавливает Python 3.12 и зависимости из `requirements.txt`.
+- Прогоняет миграции и выполняет `python manage.py test` на SQLite.
+- При падении тестов деплой не запускается.
+
+### Job `deploy`
+- Запускается только для ветки `develop`, если тесты завершились успешно.
+- Подключается к серверу по SSH (используется секретный ключ) и выполняет скрипт `deploy/deploy.sh`.
+- Скрипт перезапускает systemd-сервис, поэтому приложение обновляется автоматически.
+
+### Секреты, которые нужно добавить в настройках репозитория
+| Имя секрета | Назначение |
+|-------------|------------|
+| `DEPLOY_SSH_KEY` | Закрытый SSH-ключ с доступом к пользователю на сервере |
+| `DEPLOY_HOST` | Домен или IP удалённого сервера |
+| `DEPLOY_USER` | Пользователь на сервере (например, `deploy`) |
+| `DEPLOY_APP_DIR` | Путь к каталогу приложения (`/srv/hw_sp_30_1/app`) |
+| `DEPLOY_VENV_PATH` | Путь к виртуальному окружению (`/srv/hw_sp_30_1/venv`) |
+| `DEPLOY_SERVICE_NAME` | Имя systemd-сервиса (по умолчанию `hw_sp_30_1`) |
+| `DEPLOY_ENV_FILE` | (Опционально) путь до `.env`, если отличается от `APP_DIR/.env` |
+
+Добавьте публичный ключ, соответствующий `DEPLOY_SSH_KEY`, в файл `~/.ssh/authorized_keys` на сервере.
+
+---
+
+## 📦 Шаблон переменных окружения
+
+Файл `.env.example` содержит минимальный набор переменных для продакшена и локального запуска. Скопируйте его в `.env` и заполните значения перед деплоем или запуском через Docker Compose.

--- a/config/settings.py
+++ b/config/settings.py
@@ -30,7 +30,17 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True if os.getenv('DEBUG') == 'True' else False
 
-ALLOWED_HOSTS = []
+
+def _split_env(value: str | None) -> list[str]:
+    """Split comma-separated env values into a clean list."""
+
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+ALLOWED_HOSTS = _split_env(os.getenv("ALLOWED_HOSTS")) or ["127.0.0.1", "localhost"]
+CSRF_TRUSTED_ORIGINS = _split_env(os.getenv("CSRF_TRUSTED_ORIGINS"))
 
 
 # Application definition
@@ -83,16 +93,26 @@ WSGI_APPLICATION = 'config.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.getenv("DB_NAME"),
-        'USER': os.getenv("DB_USER"),
-        'PASSWORD': os.getenv("DB_PASSWORD"),
-        'HOST': os.getenv("DB_HOST"),
-        'PORT': os.getenv("DB_PORT"),
+DB_ENGINE = os.getenv("DB_ENGINE", "sqlite").lower()
+
+if DB_ENGINE == "postgres" or DB_ENGINE == "postgresql":
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': os.getenv("DB_NAME"),
+            'USER': os.getenv("DB_USER"),
+            'PASSWORD': os.getenv("DB_PASSWORD"),
+            'HOST': os.getenv("DB_HOST", "127.0.0.1"),
+            'PORT': os.getenv("DB_PORT", "5432"),
+        }
     }
-}
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': BASE_DIR / 'db.sqlite3',
+        }
+    }
 
 
 # Password validation
@@ -130,6 +150,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = 'static/'
+STATIC_ROOT = BASE_DIR / 'staticfiles'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${APP_DIR:-}" ]]; then
+  echo "APP_DIR environment variable is required" >&2
+  exit 1
+fi
+
+VENV_PATH=${VENV_PATH:-"$APP_DIR/venv"}
+GIT_REF=${GIT_REF:-"develop"}
+PYTHON_BIN="${PYTHON_BIN:-$VENV_PATH/bin/python}"
+PIP_BIN="${PIP_BIN:-$VENV_PATH/bin/pip}"
+SERVICE_NAME=${SERVICE_NAME:-"hw_sp_30_1"}
+ENV_FILE=${ENV_FILE:-"$APP_DIR/.env"}
+
+if [[ ! -d "$APP_DIR" ]]; then
+  echo "Application directory $APP_DIR does not exist" >&2
+  exit 1
+fi
+
+cd "$APP_DIR"
+
+echo "[deploy] Fetching latest code for $GIT_REF"
+if [[ ! -d .git ]]; then
+  echo "Directory $APP_DIR is not a git repository" >&2
+  exit 1
+fi
+
+git fetch origin "$GIT_REF"
+git checkout "$GIT_REF"
+git reset --hard "origin/$GIT_REF"
+
+echo "[deploy] Ensuring virtual environment exists at $VENV_PATH"
+if [[ ! -d "$VENV_PATH" ]]; then
+  python3 -m venv "$VENV_PATH"
+fi
+
+source "$VENV_PATH/bin/activate"
+
+"$PIP_BIN" install --upgrade pip
+"$PIP_BIN" install -r requirements.txt
+
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+"$PYTHON_BIN" manage.py migrate --noinput
+"$PYTHON_BIN" manage.py collectstatic --noinput
+
+if command -v sudo >/dev/null 2>&1; then
+  echo "[deploy] Restarting service $SERVICE_NAME via sudo"
+  sudo systemctl restart "$SERVICE_NAME"
+else
+  echo "[deploy] Restarting service $SERVICE_NAME without sudo"
+  systemctl restart "$SERVICE_NAME"
+fi
+
+echo "[deploy] Deployment completed"

--- a/infra/hw_sp_30_1.service
+++ b/infra/hw_sp_30_1.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Gunicorn service for HW_SP_30_1 Django application
+After=network.target
+
+[Service]
+Type=simple
+User=www-data
+Group=www-data
+WorkingDirectory=/srv/hw_sp_30_1/app
+EnvironmentFile=/srv/hw_sp_30_1/app/.env
+ExecStart=/srv/hw_sp_30_1/venv/bin/gunicorn config.wsgi:application \
+  --bind 0.0.0.0:8000 \
+  --workers 4 \
+  --access-logfile /var/log/hw_sp_30_1/access.log \
+  --error-logfile /var/log/hw_sp_30_1/error.log
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    server_name example.com www.example.com;
+
+    location /static/ {
+        alias /srv/hw_sp_30_1/app/staticfiles/;
+    }
+
+    location /media/ {
+        alias /srv/hw_sp_30_1/app/media/;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Summary
- refine Django settings for environment-driven hosts and database selection and update the `.env` template
- add a reusable deployment script, systemd and Nginx configuration samples, and document production setup steps
- introduce a CI/CD workflow that runs tests on push and deploys to the server after successful checks

## Testing
- not run (package installation blocked by proxy in execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69118a2b16f88328bc566ce5fb98edfb)